### PR TITLE
Close #2 MemoryStream discards buffer before it is read

### DIFF
--- a/src/MemoryStream.php
+++ b/src/MemoryStream.php
@@ -260,7 +260,7 @@ class MemoryStream implements DuplexStream
 
         $this->buffer->push($data);
 
-        if (null !== $this->delayed && !$this->buffer->isEmpty()) {
+        if (null !== $this->delayed && $this->delayed->isPending() && !$this->buffer->isEmpty()) {
             $this->delayed->resolve($this->remove());
         }
 


### PR DESCRIPTION
Closes issue #2 MemoryStream discards buffer before it is read.
